### PR TITLE
Small change of inline docs

### DIFF
--- a/src/Deepzoom.php
+++ b/src/Deepzoom.php
@@ -263,7 +263,7 @@ EOF;
     {
         // trim space
         $string = trim($string);
-        // replace strings and dashes with underscore
+        // replace strings, dashes and whitespaces with underscore
         return str_replace(['/\s/', '-', ' '], '_', $string);
     }
 
@@ -275,7 +275,7 @@ EOF;
     {
         // trim space
         $string = trim($string);
-        // replace strings and dashes with dash
+        // replace strings and whitespaces with dash
         return str_replace(['/\s/', ' '], '-', $string);
     }
 


### PR DESCRIPTION
Just improving inline comments in the cleanup functions for files and folders.

And by the way: Is there a reason why file names and folder names get treated differently regarding the cleanup (dash replacement for folder names and whitespace replacements for file names)?