### PR TITLE
Fix PHP 8.2 deprecated dynamic property warnings

### DIFF
--- a/src/Deepzoom.php
+++ b/src/Deepzoom.php
@@ -16,6 +16,8 @@ class Deepzoom
     private $tileSize;
     private $tileOverlap;
     private $pathPrefix;
+    private $imageManager;
+    private $path;
 
     /**
      * @param FilesystemOperator $path


### PR DESCRIPTION
PHP 8.2 deprecated dynamic property creation; `$imageManager` and `$path` were being assigned in setter methods without being declared as class properties, triggering deprecation warnings at runtime.

## Changes

- **`src/Deepzoom.php`**: Explicitly declare `$imageManager` and `$path` as `private` class properties alongside the existing property declarations.